### PR TITLE
doc(project): kick off proposals

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-# standards
+# Standards
+
 Recommended standards for JavaScript.

--- a/proposed/coding-style.md
+++ b/proposed/coding-style.md
@@ -1,0 +1,3 @@
+# Coding style
+
+[TBD]

--- a/proposed/commit-messages.md
+++ b/proposed/commit-messages.md
@@ -1,0 +1,57 @@
+# Commit messages
+
+[TBD, content is a starting point]
+
+We have very precise rules over how our git commit messages can be formatted.  This leads to **more
+readable messages** that are easy to follow when looking through the **project history**.  But also,
+we use the git commit messages to **generate the change log**.
+
+## Commit Message Format
+
+Each commit message consists of a **header**, a **body** and a **footer**.  The header has a special
+format that includes a **type**, a **scope** and a **subject**:
+
+```plain
+<type>(<scope>): <subject>
+<BLANK LINE>
+<body>
+<BLANK LINE>
+<footer>
+```
+
+The subject line of the commit message cannot be longer 100 characters. This allows the message to be easier to read on GitHub as well as in various git tools.
+
+### Type
+
+Please use one of the following:
+
+* **feat**: A new feature
+* **fix**: A bug fix
+* **doc**: Documentation only changes
+* **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing
+  semi-colons, etc)
+* **refactor**: A code change that neither fixes a bug or adds a feature
+* **perf**: A code change that improves performance
+* **test**: Adding missing tests
+* **chore**: Changes to the build process or auxiliary tools and libraries such as documentation
+  generation
+
+### Scope
+
+The scope could be anything specifying the location of the commit change. For example `view-compiler` or `logger`.
+
+### Subject
+
+The subject contains a succinct description of the change:
+
+* Use the imperative, present tense: "change" not "changed" nor "changes".
+* Don't capitalize the first letter.
+* Do not add a dot (.) at the end.
+
+### Body
+
+The body should include the motivation for the change and contrast this with previous behavior.
+
+### Footer
+
+The footer should contain any information about **Breaking Changes** and is also the place to reference GitHub issues that this commit **Closes**.

--- a/proposed/contributing.md
+++ b/proposed/contributing.md
@@ -1,0 +1,8 @@
+# Contributing guidelines
+
+* Branch names
+* Forking
+* Tests
+* Coding style
+
+[TBD]


### PR DESCRIPTION
With this PR I want to kick-off the format of the repository. I propose:

* Using markdown for the documents
* Separating proposals and accepted standards
* Documenting the goal of this org
* Setting up a board of final voters